### PR TITLE
WIP

### DIFF
--- a/about.json
+++ b/about.json
@@ -9,5 +9,8 @@
   "minimum_discourse_version": null,
   "maximum_discourse_version": null,
   "assets": { "background_video": "assets/eclipse_web.mp4" },
-  "modifiers": {}
+  "modifiers": {
+    "custom_homepage": "true",
+    "svg_icons": ["comments", "heart", "key", "plane"]
+  }
 }

--- a/common/common.scss
+++ b/common/common.scss
@@ -1,74 +1,394 @@
-// Theme's SCSS
-.hidden {
-  display: none;
-}
-.landing-page-content {
-  position: relative; /* Ensures proper stacking within the parent container */
-  background-color: rgba(
-    255,
-    255,
-    255,
-    0.5
-  ); /* Sets a semi-transparent background */
-  z-index: 2; /* Keeps it above the video */
-}
+@import url("https://fonts.googleapis.com/css2?family=Raleway:wght@300;900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;900&display=swap");
 
-.landing-page {
-  position: relative;
-}
+body.has-landing-page {
+  font-family: "Roboto", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  font-weight: 300;
 
-.background-video {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  z-index: -1; /* Places the video behind other elements */
-}
-
-.container {
-  width: 100%;
-  padding-right: 0px;
-  padding-left: 0px;
-}
-
-body {
   background: none;
-}
+  overflow-x: hidden;
 
-#header {
-  background-color: transparent;
-  border: none;
-}
+  .d-header {
+    background: transparent;
+    box-shadow: none;
 
-section {
-  padding: 50px 0;
-}
+    .text-logo {
+      color: #fff;
+    }
+  }
 
-.navbar-fixed-bottom,
-.navbar-fixed-top {
-  position: absolute;
-}
+  .header-sidebar-toggle,
+  .sidebar-wrapper {
+    display: none;
+  }
 
-.row {
-  margin-right: 0px;
-  margin-left: 0px;
-}
+  &.has-sidebar-page #main-outlet-wrapper {
+    display: block;
+    max-width: 100%;
 
-header .intro-content {
-  position: absolute;
-  width: 80%;
-  bottom: -30px;
-  left: 43%;
-  text-align: left;
-  top: auto;
-}
+    #main-outlet {
+      padding-top: 0;
+    }
+  }
 
-header .scroll-down {
-  position: absolute;
-  width: 100%;
-  bottom: 30px;
-  text-align: right;
-  padding-right: 50px;
+  #main {
+    padding: 0;
+  }
+
+  .landing-page {
+    transition: opacity 0.5s linear;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    position: relative;
+    margin-top: calc(-1 * var(--header-offset));
+  }
+
+  .background-video {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    max-height: 100%;
+    object-fit: cover;
+    z-index: -1;
+    pointer-events: none;
+  }
+
+  .intro-content {
+    position: absolute;
+    left: 4%;
+    bottom: 30px;
+    width: 80%;
+
+    .brand-name {
+      font-family: "Raleway", "Helvetica Neue", Helvetica, Arial, sans-serif;
+      font-size: 55px;
+      line-height: 55px;
+      text-transform: uppercase;
+      font-weight: bold;
+      margin-top: 15px;
+      color: white;
+    }
+  }
+
+  .scroll-down {
+    position: absolute;
+    right: 3em;
+    bottom: 30px;
+
+    .e-btn {
+      height: 50px;
+      width: 50px;
+      border: 2px solid white;
+      border-radius: 100% !important;
+      line-height: 50px;
+      padding: 0;
+      letter-spacing: normal;
+      color: white;
+      font-size: 25px;
+      transition: all 0.5s;
+      background: transparent;
+
+      svg {
+        color: white;
+
+        margin-right: inherit;
+      }
+    }
+  }
+
+  .about-content {
+    padding: 30px;
+
+    svg {
+      font-size: 4em;
+    }
+  }
+
+  .animated {
+    animation-duration: 1s;
+    animation-fill-mode: both;
+  }
+
+  .e-btn {
+    display: inline-block;
+    padding: 6px 12px;
+    margin-bottom: 0;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 1.42857143;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    touch-action: manipulation;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .e-btn {
+    border-radius: 0;
+    padding: 12px 18px;
+    text-transform: uppercase;
+    font-weight: 900;
+    letter-spacing: 1px;
+    transition: all 0.5s;
+  }
+
+  .e-btn-outline-dark {
+    color: #222222;
+    border: 1px solid #222222;
+    background: transparent;
+    transition: all 0.5s;
+  }
+
+  .e-btn.focus,
+  .e-btn:focus,
+  .e-btn:hover {
+    color: #333;
+    text-decoration: none;
+  }
+
+  .e-btn.active,
+  .e-btn:active {
+    background-image: none;
+    outline: 0;
+    box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  }
+
+  .e-btn-outline-dark:hover,
+  .e-btn-outline-dark:focus {
+    color: white;
+    background: #2a2f78;
+    border-color: #2a2f78;
+    outline: none;
+  }
+
+  .e-btn-outline-light {
+    color: white;
+    border: 1px solid white;
+    background: transparent;
+    transition: all 0.5s;
+  }
+  .e-btn-outline-light:hover,
+  .e-btn-outline-light:focus {
+    color: #2a2f78;
+    background: white;
+    outline: none;
+  }
+
+  .e-btn-full-width {
+    border: 0;
+    border-radius: 0;
+    background-color: #222222;
+    color: white;
+    padding: 50px 0;
+    font-size: 26px;
+    font-weight: 200;
+    letter-spacing: normal;
+    text-transform: none;
+
+    &:hover {
+      background-color: #2a2f78;
+      color: white;
+    }
+
+    &:focus {
+      color: white;
+    }
+  }
+
+  .e-btn-block {
+    display: block;
+    width: 100%;
+  }
+
+  aside.cta-quote {
+    color: white;
+    background-color: #222222;
+    background: no-repeat center center scroll;
+    background-size: cover;
+    padding: 100px 0;
+    text-align: center;
+  }
+
+  aside.cta-quote span.quote {
+    display: block;
+    font-size: 30px;
+    line-height: 32px;
+    font-weight: 300;
+  }
+
+  @media (min-width: 768px) {
+    aside.cta-quote {
+      background-attachment: scroll;
+      padding: 150px 0;
+    }
+    aside.cta-quote span.quote {
+      font-size: 36px;
+      line-height: 38px;
+    }
+  }
+  @media (min-width: 992px) {
+    aside.cta-quote {
+      padding: 300px 0;
+    }
+    aside.cta-quote span.quote {
+      font-size: 40px;
+      line-height: 42px;
+    }
+  }
+  @media (min-width: 1025px) {
+    aside.cta-quote {
+      background-attachment: fixed;
+    }
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: "Raleway", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: 900;
+    text-transform: uppercase;
+  }
+
+  h1,
+  h2,
+  h3 {
+    margin-top: 20px;
+    margin-bottom: 10px;
+  }
+
+  h1 {
+    font-size: 52px;
+    font-family: "Raleway", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-weight: 900;
+    text-transform: uppercase;
+    margin-top: 20px;
+    margin-bottom: 10px;
+    line-height: 1.1;
+    color: rgb(51, 51, 51);
+  }
+
+  h3 {
+    font-size: 24px;
+  }
+
+  section {
+    padding: 50px 0;
+  }
+
+  .container-fluid {
+    padding-right: 15px;
+    padding-left: 15px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+
+  @media (min-width: 1200px) {
+    .container {
+      width: 1170px;
+    }
+  }
+
+  @media (min-width: 992px) {
+    .container {
+      width: 970px;
+    }
+  }
+  @media (min-width: 768px) {
+    .container {
+      width: 750px;
+    }
+  }
+  .container {
+    padding-right: 15px;
+    padding-left: 15px;
+    margin-right: auto;
+    margin-left: auto;
+  }
+
+  .container {
+    width: 100%;
+    padding-right: 0px;
+    padding-left: 0px;
+  }
+
+  .row {
+    margin-right: 0px;
+    margin-left: 0px;
+  }
+
+  .content-row {
+    margin-top: 30px;
+  }
+
+  .text-center {
+    text-align: center;
+  }
+
+  p {
+    font-size: 18px;
+    line-height: 1.5;
+    margin: 0 0 10px;
+    font-weight: 300;
+  }
+
+  @media (min-width: 1200px) {
+    .col-lg-12 {
+      width: 100%;
+    }
+  }
+
+  @media (min-width: 992px) {
+    .col-md-3 {
+      width: 25%;
+    }
+  }
+
+  @media (min-width: 992px) {
+    .col-md-1,
+    .col-md-10,
+    .col-md-11,
+    .col-md-12,
+    .col-md-2,
+    .col-md-3,
+    .col-md-4,
+    .col-md-5,
+    .col-md-6,
+    .col-md-7,
+    .col-md-8,
+    .col-md-9 {
+      float: left;
+    }
+  }
+
+  @media (min-width: 992px) {
+    .col-md-offset-1 {
+      margin-left: 8.33333333%;
+    }
+  }
+
+  @media (min-width: 992px) {
+    .col-md-10 {
+      width: 83.33333333%;
+    }
+  }
+
+  @media (min-width: 992px) {
+    body.has-landing-page .col-md-10 {
+      width: 83.33333333%;
+    }
+  }
+
+  @media (min-width: 992px) {
+    body.has-landing-page .col-md-offset-1 {
+      margin-left: 8.33333333%;
+    }
+  }
 }

--- a/javascripts/discourse/api-initializers/landing-page-component.gjs
+++ b/javascripts/discourse/api-initializers/landing-page-component.gjs
@@ -1,7 +1,24 @@
 import { apiInitializer } from "discourse/lib/api";
+import { defaultHomepage } from "discourse/lib/utilities";
 import LandingPage from "../components/landing-page";
 
-export default apiInitializer("1.8.0", (api) => {
-  // see if we're on the home page
-  api.renderInOutlet("after-header", LandingPage);
+export default apiInitializer((api) => {
+  // https://github.com/discourse/discourse/pull/26291
+  api.renderInOutlet("custom-homepage", LandingPage);
+
+  const router = api.container.lookup("service:router");
+  const currentUser = api.getCurrentUser();
+
+  // After logging in, the user is redirected to /custom.
+  // Redirects /custom to the default homepage.
+  // Also ignores the /custom route if the user is logged out.
+  router.on("routeWillChange", (transition) => {
+    if (
+      transition.intent?.url === "/custom" &&
+      transition.to?.name === "discovery.custom"
+    ) {
+      transition.abort();
+      router.transitionTo(currentUser ? `discovery.${defaultHomepage()}` : "/");
+    }
+  });
 });

--- a/javascripts/discourse/components/landing-page.gjs
+++ b/javascripts/discourse/components/landing-page.gjs
@@ -1,244 +1,216 @@
 import Component from "@glimmer/component";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import willDestroy from "@ember/render-modifiers/modifiers/will-destroy";
 import { service } from "@ember/service";
-import DButton from "discourse/components/d-button";
-import concatClass from "discourse/helpers/concat-class";
+import icon from "discourse/helpers/d-icon";
 
 export default class LandingPage extends Component {
   @service currentUser;
   @service router;
   @service siteSettings;
 
-  get shouldRender() {
-    const isHomePage = true && this.router.currentURL === "/";
-    console.log("shouldRender is happening", this, this.background_video);
-    // add hidden class to #main-outlet-wrapper if on home page
-    return isHomePage;
+  @action
+  addClass() {
+    document.body.classList.add("has-landing-page");
   }
 
-  get hideMainOutletWrapper() {
-    console.log(
-      "hideMainOutletWrapper is happening",
-      this,
-      settings.theme_uploads.background_video
-    );
-    const isHomePage = this.router.currentURL === "/";
-    document.addEventListener("DOMContentLoaded", () => {
-      if (isHomePage) {
-        const mainOutletWrapper = document.querySelector(
-          "#main-outlet-wrapper"
-        );
-        console.log("isHomePage is true");
-        if (mainOutletWrapper) {
-          mainOutletWrapper.classList.add("hidden");
-        }
-      } else {
-        const mainOutletWrapper = document.querySelector(
-          "#main-outlet-wrapper"
-        );
-        if (mainOutletWrapper) {
-          mainOutletWrapper.classList.remove("hidden");
-        }
-      }
-    });
-    // add hidden class to #main-outlet-wrapper if on home page
-    if (isHomePage) {
-      const mainOutletWrapper = document.querySelector("#main-outlet-wrapper");
-      console.log("isHomePage is true");
-      if (mainOutletWrapper) {
-        mainOutletWrapper.classList.add("hidden");
-      }
-    } else {
-      const mainOutletWrapper = document.querySelector("#main-outlet-wrapper");
-      if (mainOutletWrapper) {
-        mainOutletWrapper.classList.remove("hidden");
-      }
-    }
+  @action
+  removeClass() {
+    document.body.classList.remove("has-landing-page");
   }
-  get button() {
-    return this.args.button;
+
+  @action
+  scrollIntoView(event) {
+    event.target.scrollIntoView({ behavior: "smooth" });
+    event.preventDefault();
   }
 
   <template>
-    {{#if this.shouldRender}}
-      <div class="landing-page">
-        <video autoplay muted loop class="background-video">
-          <source
-            src="{{settings.theme_uploads.background_video}}"
-            type="video/mp4"
-          />
-          Your browser does not support the video tag.
-        </video>
-        <div class="landing-page__content">
-          <section id="about">
-            <div class="container-fluid">
-              <div class="row text-center">
-                <div class="col-lg-12 wow">
-                  <h1>
-                    Dedicated to the safe, economical and fun operation of the
-                    Eclipse Jet
-                  </h1>
-                  <p>
-                    EJOPA brings together like minded individuals that share the
-                    joy of aviation and the delight of flying the Eclipse Jet
-                  </p>
-                </div>
-              </div>
-              <div class="row text-center content-row">
-                <div class="col-md-3 col-sm-6 wow">
-                  <div class="about-content">
-                    <i class="fa fa-comments-o fa-4x"></i>
-                    <h3>Experienced Community</h3>
-                    <p style="text-align: left">
-                      EJOPA's active forums provides essential information on
-                      all aspects of Eclipse ownership. Members have contributed
-                      more than 95,000 posts covering every subject matter
-                      including safety, training, operations, parts, service,
-                      modifications and much more!
-                    </p>
-                  </div>
-                </div>
-                <div class="col-md-3 col-sm-6 wow">
-                  <div class="about-content">
-                    <i class="fa fa-heart fa-4x"></i>
-                    <h3>Advocacy</h3>
-                    <p style="text-align: left">
-                      EJOPA provides an unvarnished two-way communication link
-                      between Eclipse Aerospace and our members. We actively
-                      advocate on behalf of our membership, which currently
-                      represents two-thirds of the Eclipse Jet fleet.
-                    </p>
-                  </div>
-                </div>
-                <div class="col-md-3 col-sm-6 wow">
-                  <div class="about-content">
-                    <i class="fa fa-plane fa-4x"></i>
-                    <h3>Convention</h3>
-                    <p style="text-align: left">
-                      EJOPA hosts several educational and social events,
-                      including our flagship
-                      <a
-                        href="/convention.php"
-                        style="text-decoration: underline"
-                      >Annual Convention</a>. The 2024 convention will be held
-                      in Fairhope, Alabama.
-                    </p>
-                  </div>
-                </div>
-                <div class="col-md-3 col-sm-6 wow">
-                  <div class="about-content">
-                    <i class="fa fa-key fa-4x"></i>
-                    <h3>Member Benefits</h3>
-                    <p style="text-align: left">
-                      Timely communications with fellow Eclipse pilots and
-                      owners.
-                      <br /><br />
+    <div
+      class="landing-page"
+      {{didInsert this.addClass}}
+      {{willDestroy this.removeClass}}
+    >
+      <video autoplay muted loop playsinline class="background-video">
+        <source
+          src="{{settings.theme_uploads.background_video}}"
+          type="video/mp4"
+        />
+        Your browser does not support the video tag.
+      </video>
 
-                      Savings on your Jepp subscriptions.<br /><br />
-
-                      Extensive library of Eclipse training videos, the perfect
-                      prep before type-rating or recurrent training.
-                      <a
-                        style="text-decoration: underline"
-                        href="https://vimeo.com/160978077"
-                        data-lity
-                      >Watch Sample</a>
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div class="row text-center">
-                <div class="col-lg-12 wow">
-                  <a class="btn btn-outline-dark" href="/register.php">Join
-                    EJOPA Today</a>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <aside
-            class="cta-quote"
-            style="background-image: url('custom_uploads/frontpage/img/fp1.jpg')"
-          >
-            <div class="container">
-              <div class="row">
-                <div class="col-md-10 col-md-offset-1">
-                  <br /><br /><br /><br />
-                  <a
-                    class="btn btn-outline-light page-scroll"
-                    href="/register.php"
-                  >Join EJOPA Today</a>
-                </div>
-              </div>
-            </div>
-          </aside>
-
-          <section
-            class="cta-quote"
-            style="
-        background-image: url('custom_uploads/frontpage/img/fp2.jpg');
-        height: 100%;
-        background-size: cover;
-      "
-          >
-            <div
-              class="container-fluid"
-              style="
-          position: relative;
-          top: 50%;
-          -webkit-transform: translateY(-50%);
-          -ms-transform: translateY(-50%);
-          transform: translateY(-50%);
-        "
-            >
-              <div class="row text-center">
-                <div class="col-md-10 col-md-offset-1">
-                  <span
-                    style="font-size: 40px; line-height: 42px; color: white"
-                  >We welcome all Eclipse owners and encourage anyone interested
-                    in this “gem of a jet” to join us so we can help with your
-                    purchase decision.<br /><br />
-                    It only costs $125 to join and you get immediate access.
-                  </span>
-                  <br /><br /><br /><br /><a
-                    class="btn btn-outline-light page-scroll"
-                    href="/register.php"
-                  >Join EJOPA Today</a>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <aside
-            class="cta-quote"
-            style="background-image: url('custom_uploads/frontpage/img/fp3.jpg')"
-          >
-            <div class="container">
-              <div class="row">
-                <div class="col-md-10 col-md-offset-1">
-                  <span
-                    style="font-size: 40px; line-height: 42px; color: white"
-                  >EJOPA contains the most extensive body of information and
-                    reference material about the Eclipse aircraft, making EJOPA
-                    the perfect place for Eclipse owners, pilots and potential
-                    owners to learn about and share their Eclipse experience.
-                  </span>
-                  <br /><br /><br /><br />
-                  <a
-                    class="btn btn-outline-light page-scroll"
-                    href="/register.php"
-                  >Join EJOPA Today</a>
-                </div>
-              </div>
-            </div>
-          </aside>
-
-          <a href="/register.php" class="btn btn-block btn-full-width">Become a
-            Member Today!</a>
-
-        </div>
+      <div class="intro-content">
+        <div class="brand-name">Welcome to the Eclipse Jet Owners &amp; Pilots
+          Association</div>
       </div>
-      {{this.hideMainOutletWrapper}}
-    {{/if}}
+
+      <div class="scroll-down page-scroll">
+        <a
+          class="e-btn page-scroll"
+          href="#about"
+          {{on "click" this.scrollIntoView}}
+        >{{icon "angle-down"}}</a>
+      </div>
+    </div>
+
+    <div class="landing-page__content">
+      <section id="about">
+        <div class="container-fluid">
+          <div class="row text-center">
+            <div class="col-lg-12 wow">
+              <h1>
+                Dedicated to the safe, economical and fun operation of the
+                Eclipse Jet
+              </h1>
+              <p>
+                EJOPA brings together like minded individuals that share the joy
+                of aviation and the delight of flying the Eclipse Jet
+              </p>
+            </div>
+          </div>
+          <div class="row text-center content-row">
+            <div class="col-md-3 col-sm-6 wow">
+              <div class="about-content">
+                {{icon "comments"}}
+                <h3>Experienced Community</h3>
+                <p style="text-align: left">
+                  EJOPA's active forums provides essential information on all
+                  aspects of Eclipse ownership. Members have contributed more
+                  than 95,000 posts covering every subject matter including
+                  safety, training, operations, parts, service, modifications
+                  and much more!
+                </p>
+              </div>
+            </div>
+            <div class="col-md-3 col-sm-6 wow">
+              <div class="about-content">
+                {{icon "heart"}}
+                <h3>Advocacy</h3>
+                <p style="text-align: left">
+                  EJOPA provides an unvarnished two-way communication link
+                  between Eclipse Aerospace and our members. We actively
+                  advocate on behalf of our membership, which currently
+                  represents two-thirds of the Eclipse Jet fleet.
+                </p>
+              </div>
+            </div>
+            <div class="col-md-3 col-sm-6 wow">
+              <div class="about-content">
+                {{icon "plane"}}
+                <h3>Convention</h3>
+                <p style="text-align: left">
+                  EJOPA hosts several educational and social events, including
+                  our flagship
+                  <a
+                    href="/convention.php"
+                    style="text-decoration: underline"
+                  >Annual Convention</a>. The 2024 convention will be held in
+                  Fairhope, Alabama.
+                </p>
+              </div>
+            </div>
+            <div class="col-md-3 col-sm-6 wow">
+              <div class="about-content">
+                {{icon "key"}}
+                <h3>Member Benefits</h3>
+                <p style="text-align: left">
+                  Timely communications with fellow Eclipse pilots and owners.
+                  <br /><br />
+
+                  Savings on your Jepp subscriptions.<br /><br />
+
+                  Extensive library of Eclipse training videos, the perfect prep
+                  before type-rating or recurrent training.
+                  <a
+                    style="text-decoration: underline"
+                    href="https://vimeo.com/160978077"
+                    data-lity
+                  >Watch Sample</a>
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="row text-center">
+            <div class="col-lg-12 wow">
+              <a class="e-btn e-btn-outline-dark" href="/register.php">Join
+                EJOPA Today</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <aside
+        class="cta-quote"
+        style="background-image: url('https://www.eclipsejetpilots.org/custom_uploads/frontpage/img/fp1.jpg')"
+      >
+        <div class="container">
+          <div class="row">
+            <div class="col-md-10 col-md-offset-1">
+              <br /><br /><br /><br />
+              <a
+                class="e-btn e-btn-outline-light page-scroll"
+                href="/register.php"
+              >Join EJOPA Today</a>
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      <section
+        class="cta-quote"
+        style="background-image: url('https://www.eclipsejetpilots.org/custom_uploads/frontpage/img/fp2.jpg'); background-size: cover; height: 89vh;"
+      >
+        <div
+          class="container-fluid"
+          style="position: relative; top: 50%; transform: translateY(-50%); display: flex; align-items: center;"
+        >
+          <div class="row text-center">
+            <div class="col-md-10 col-md-offset-1">
+              <span style="font-size: 40px; line-height: 42px; color: white">We
+                welcome all Eclipse owners and encourage anyone interested in
+                this “gem of a jet” to join us so we can help with your purchase
+                decision.<br /><br />
+                It only costs $125 to join and you get immediate access.
+              </span>
+              <br /><br /><br /><br /><a
+                class="e-btn e-btn-outline-light page-scroll"
+                href="/register.php"
+              >Join EJOPA Today</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <aside
+        class="cta-quote"
+        style="background-image: url('https://www.eclipsejetpilots.org/custom_uploads/frontpage/img/fp3.jpg')"
+      >
+        <div class="container">
+          <div class="row">
+            <div class="col-md-10 col-md-offset-1">
+              <span
+                style="font-size: 40px; line-height: 42px; color: white"
+              >EJOPA contains the most extensive body of information and
+                reference material about the Eclipse aircraft, making EJOPA the
+                perfect place for Eclipse owners, pilots and potential owners to
+                learn about and share their Eclipse experience.
+              </span>
+              <br /><br /><br /><br />
+              <a
+                class="e-btn e-btn-outline-light page-scroll"
+                href="/register.php"
+              >Join EJOPA Today</a>
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      <a href="/register.php" class="e-btn e-btn-block e-btn-full-width">Become
+        a Member Today!</a>
+
+    </div>
   </template>
 }


### PR DESCRIPTION
I remembered you can have a custom homepage, so I gave it a try: https://github.com/discourse/discourse/pull/26291
This means there is no topic list, and you no longer need to hide it.
You use "custom-homepage" outlet here. The sidebar still needs to be hidden.
The only issue I encountered is that after you log in, it redirects to /custom. So I had to make another redirect to homepage. It may have another way; I know there is a destination URL, but I'm not sure if it can be used here.

The HTML is essentially untouched.

I added a classname in the body to make it easier to target in the CSS.
I used modifiers: `{{didInsert this.addClass}} ` `{{willDestroy this.removeClass}}`

To make the button scroll to view, I added a click event: `{{on "click" this.scrollIntoView}}``
```js
@action
  scrollIntoView(event) {
    event.target.scrollIntoView({ behavior: "smooth" });
    event.preventDefault();
  }
```
The CSS added is a bit messy. I had to import bootstrap CSS here and there.
I didn't check how it displays on mobile, so it might be a good idea to check for missing CSS.

Sometimes the video won't play; I'm not sure why yet likely because there is no initial user interaction. It must have a way since it works on the other site.


